### PR TITLE
Modify Code-runner's executorMap to attach math lib

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "code-runner.executorMap":{
+    "c": "cd $dir && gcc $fileName -lm -o $fileNameWithoutExt && $dir$fileNameWithoutExt"
+    }
+}


### PR DESCRIPTION
Fix compilation problem in Linux which require you to manually attack library.

However, this fix only work for code-runner.